### PR TITLE
Fix erroneous messages about invalid package paths in html imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
+#### 0.11.4+1
+  * Fix erroneous messages about invalid package paths in html imports
+    [72](https://github.com/dart-lang/polymer-dart/issues/72).
+
 #### 0.11.4
-  * Update to analyzer <=0.26.0.
+  * Update to analyzer `<0.26.0`.
 
 #### 0.11.3+1
   * Fix bootstrap to return the result of the original main.

--- a/lib/src/mirror_initializer.dart
+++ b/lib/src/mirror_initializer.dart
@@ -167,8 +167,8 @@ final entryPath = document.baseUri;
 /// Checks that the relative path from the entry point to all packages imports
 /// starts with `packages/`.
 bool _checkPackagePath(LinkElement import) {
-  var pathFromEntryPoint =
-      url.relative(import.href, from: url.dirname(entryPath));
+  var dirname = entryPath.endsWith('/') ? entryPath : url.dirname(entryPath);
+  var pathFromEntryPoint = url.relative(import.href, from: dirname);
   if (pathFromEntryPoint.startsWith('packages/')) return true;
 
   LinkElement correctedImport = import.clone(false);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: web_components
-version: 0.11.4
+version: 0.11.4+1
 author: Polymer.dart Authors <web-ui-dev@dartlang.org>
 homepage: https://www.dartlang.org/polymer-dart/
 description: >


### PR DESCRIPTION
fixes https://github.com/dart-lang/polymer-dart/issues/72
