### PR TITLE
don't inline type='css' imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#### 0.11.4+2
+  * Don't inline type="css" imports.
+
 #### 0.11.4+1
   * Fix erroneous messages about invalid package paths in html imports
     [72](https://github.com/dart-lang/polymer-dart/issues/72).

--- a/lib/build/import_crawler.dart
+++ b/lib/build/import_crawler.dart
@@ -54,7 +54,9 @@ class ImportCrawler {
       seen.add(assetId);
 
       Future crawlImports(Document document) {
-        var imports = document.querySelectorAll('link[rel="import"]');
+        var imports = document
+            .querySelectorAll('link[rel="import"]')
+            .where((import) => import.attributes['type'] != 'css');
         var done = Future.forEach(imports,
             (i) => doCrawl(_importId(assetId, i), import: i, from: assetId));
 

--- a/lib/build/import_inliner.dart
+++ b/lib/build/import_inliner.dart
@@ -71,13 +71,16 @@ class ImportInliner {
       if (imports.length > 1) {
         _inlineImports(primaryDocument, imports);
       } else if (!changed &&
-          primaryDocument.querySelectorAll('link[rel="import"]').length == 0) {
+          primaryDocument.querySelectorAll('link[rel="import"]').where(
+                  (import) => import.attributes['type'] != 'css').length ==
+              0) {
         // If there were no url changes and no imports, then we are done.
         return;
       }
 
       primaryDocument
           .querySelectorAll('link[rel="import"]')
+          .where((import) => import.attributes['type'] != 'css')
           .forEach((element) => element.remove());
 
       transform.addOutput(

--- a/lib/build/test_compatibility.dart
+++ b/lib/build/test_compatibility.dart
@@ -51,8 +51,8 @@ class RewriteScriptToXDartTest extends _EntryPointOnlyTransformer {
   Future apply(Transform transform) {
     return transform.primaryInput.readAsString().then((String html) {
       var doc = parse(html);
-      var scripts = doc.querySelectorAll(
-          'script[type="application/dart"][$testAttribute]');
+      var scripts = doc
+          .querySelectorAll('script[type="application/dart"][$testAttribute]');
       for (var tag in scripts) {
         tag.replaceWith(new Element.tag('link')
           ..attributes['rel'] = 'x-dart-test'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: web_components
-version: 0.11.4+1
+version: 0.11.4+2
 author: Polymer.dart Authors <web-ui-dev@dartlang.org>
 homepage: https://www.dartlang.org/polymer-dart/
 description: >

--- a/test/build/test_compatibility_test.dart
+++ b/test/build/test_compatibility_test.dart
@@ -35,7 +35,6 @@ main() {
         </html>''',
   }, [], StringFormatter.noNewlinesOrSurroundingWhitespace);
 
-
   testPhases('can rewrite script tags to x-dart-test link tags', [[end]], {
     'a|test/index.html': '''
         <!DOCTYPE html>
@@ -56,7 +55,6 @@ main() {
           <body></body>
         </html>''',
   }, [], StringFormatter.noNewlinesOrSurroundingWhitespace);
-
 
   testPhases('restores original application at the end', [[start], [end]], {
     'a|test/index.html': '''


### PR DESCRIPTION
Eventually we probably want to actually inline these, but this at least gets things working with the new special type="css" html imports.
