### PR TITLE
fix pub serve hang on reload with the web_components transformer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### 0.12.0+1
+  * Fix hang on reload with the `web_components` transformer in pub serve,
+    [27](https://github.com/dart-lang/web-components/issues/27).
+
 #### 0.12.0
   * Update to js version
     [0.7.3](https://github.com/webcomponents/webcomponentsjs/tree/v0.7.3).

--- a/lib/build/web_components.dart
+++ b/lib/build/web_components.dart
@@ -59,7 +59,6 @@ class WebComponentsTransformer extends Transformer {
     if (options.entryPoints != null) {
       return options.entryPoints.contains(id.path);
     }
-    if (id.path == 'web/index.bootstrap.dart') return true;
     // If no entry point is supplied, then any html file under web/ or test/ is
     // an entry point.
     return (id.path.startsWith('web/') || id.path.startsWith('test/')) &&
@@ -91,6 +90,7 @@ class WebComponentsTransformer extends Transformer {
         transform
             .addOutput(new Asset.fromString(primaryInput.id, doc.outerHtml));
         transform.addOutput(bootstrap);
+        resolver.release();
       });
     });
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: web_components
-version: 0.12.0
+version: 0.12.0+1
 author: Polymer.dart Authors <web-ui-dev@dartlang.org>
 homepage: https://www.dartlang.org/polymer-dart/
 description: >


### PR DESCRIPTION
fixes https://github.com/dart-lang/web-components/issues/27

I also snuck in a small cleanup of the `isPrimary` method.
